### PR TITLE
fix: add "shared" folder to files in package.json

### DIFF
--- a/packages/bulma/package.json
+++ b/packages/bulma/package.json
@@ -31,6 +31,7 @@
     "files": [
         "css",
         "sass",
+        "shared",
         "themes",
         "bulma.sass",
         "bulma-rtl.sass",


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->

This is a **bugfix**.

<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
Makes it possible to use sass files directly by including the shared folder in the bundled output.
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

❌  A little larger install size.
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

Have not tested. Not sure how to test this.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/daniil4udo/bulvar/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/daniil4udo/bulvar/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
