### PR TITLE
feature(Bulma): ✨  ability to modify default invert colors

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -217,6 +217,11 @@ Same applies for lightness. Instead of using sass lightness function (which you 
 
 Tome make color lighter increase (add) value to the `--primary-l`, to make it darker, decrease (substract) accordingly.
 
+### Modify Invert Colors
+By default, if color's luminance less then 0.55, then invert color will be `rgba(#000, 0.7)` otherwise `white`.
+
+You can change those colors now by overwriting `$invert-dark-colors` & `$invert-light-colors`
+
 ### Proper color change in runtime
 
 Best way to change main colors (primary, info etc.) is to change their coresponding `--#{$name}-h` (hue), `--#{$name}-s` (saturation),

--- a/packages/bulma/sass/utilities/functions.sass
+++ b/packages/bulma/sass/utilities/functions.sass
@@ -5,6 +5,8 @@
 @use "sass:meta"
 @use "sass:string"
 
+@use 'initial-variables' as vars
+
 @function mergeColorMaps($bulma-colors, $custom-colors)
   // We return at least Bulma's hard-coded colors
   $merged-colors: $bulma-colors
@@ -79,7 +81,7 @@
 
 /// Invert color calculation
 @function calculateInvertColor($color)
-  @return if(colorLuminance($color) > 0.55, rgba(#000, 0.7), #fff)
+  @return if(colorLuminance($color) > 0.55, vars.$invert-light-colors, vars.$invert-dark-colors)
 
 @function findColorInvert($color, $fallback: null)
   @if meta.type-of($color) == 'color'

--- a/packages/bulma/sass/utilities/initial-variables.sass
+++ b/packages/bulma/sass/utilities/initial-variables.sass
@@ -24,6 +24,11 @@ $blue:          hsl(217deg 61% 40%) !default
 $purple:        hsl(271deg 100% 71%) !default
 $red:           hsl(348deg 86% 61%) !default
 
+// Invert Colors
+
+$invert-dark-colors: rgba(#000, 0.7) !default
+$invert-light-colors: $white !default
+
 // Typography
 
 $family-sans-serif: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif !default


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

<!-- Choose one of the following: -->

This is a **new feature | improvement | bugfix | documentation fix**.

<!-- New feature? Update the CHANGELOG.md too, and eventually the Docs. -->
<!-- Improvement? Explain how and why. -->
<!-- Bugfix? Reference that issue as well. -->

### Proposed solution

<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

### Testing Done

None.

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Make sure your Sass code is compliant with the [Bulma Sass styleguide](https://github.com/daniil4udo/bulvar/blob/master/.github/CONTRIBUTING.md#bulma-sass-styleguide) -->
<!-- 3. Make sure your PR only affects `.sass` or documentation files -->
<!-- 4. [Try your changes](https://github.com/daniil4udo/bulvar/blob/master/.github/CONTRIBUTING.md#try-your-changes). -->

<!-- How have you confirmed this feature works? -->
<!-- Please explain more than "Yes". -->

### Changelog updated?

No.

<!-- Thanks! -->
